### PR TITLE
Empty files should not be decoding error.

### DIFF
--- a/Sources/L10nModels/LocalizedStringFile.swift
+++ b/Sources/L10nModels/LocalizedStringFile.swift
@@ -38,10 +38,18 @@ public struct LocalizedStringFile {
                     guard rest.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
                         return .failure(.fileParserHasUnmatchedString(self, rest: String(rest)))
                     }
-                    return match.toResult(orError: .fileCannotBeParsed(self))
+                    guard let match else {
+                        return .failure(.fileCannotBeParsed(self))
+                    }
+                    
+                    return .success((match, contents))
                 }
-                .flatMap { entries in
-                    entries.isEmpty
+                .flatMap { (entries: [LocalizedStringEntry], contents: String) in
+                    guard !contents.isEmpty else {
+                        return .success([])
+                    }
+                    
+                   return entries.isEmpty
                         ? .failure(.filePossibleEncodingProblemWhileParsing(self))
                         : .success(entries)
                 }

--- a/Tests/MergeL10nTests/ParserTests.swift
+++ b/Tests/MergeL10nTests/ParserTests.swift
@@ -3,6 +3,15 @@ import L10nModels
 import XCTest
 
 class ParserTests: XCTestCase {
+    func testEmptyFile() throws {
+        let file = ""
+
+        let (match, rest) = LocalizedStringFile.parser().run(file)
+
+        XCTAssertTrue(match?.isEmpty ?? false)
+        XCTAssertEqual("", rest)
+    }
+    
     func testSingleLine() throws {
         let file =
         """


### PR DESCRIPTION
Empty files are parsable now.