### PR TITLE
Make sure every file ends with an empty line

### DIFF
--- a/Sources/L10nModels/LocalizedStringFile.swift
+++ b/Sources/L10nModels/LocalizedStringFile.swift
@@ -65,7 +65,7 @@ public struct LocalizedStringFile {
             )
             .flatMap { contents in
                 fileManager
-                    .createTextFile(self.fullPath, contents, encoding)
+                    .createTextFile(self.fullPath, contents.appending("\n\n"), encoding)
                     ? .success(()) : .failure(LocalizedStringFileError.fileCannotBeSaved(self))
             }
         }


### PR DESCRIPTION
Fixes the "No newline at end of file” problem after running MergeL10n.